### PR TITLE
Fix Python 3.12 Syntax Warnings (use raw strings)

### DIFF
--- a/rfcat_msfrelay
+++ b/rfcat_msfrelay
@@ -295,7 +295,7 @@ class MSFHandler(BaseHTTPRequestHandler):
         elif self.path=="/rftransceiver/supported_idx":
             self.send(self.supported_idx())
         elif self.path.startswith("/rftransceiver/"):
-            re_idx = re.compile("/rftransceiver/(\d+)/")
+            re_idx = re.compile(r"/rftransceiver/(\d+)/")
             m = re_idx.match(self.path)
             if m:
                 idx = m.group(1)

--- a/rfcat_server
+++ b/rfcat_server
@@ -14,7 +14,7 @@ DATA_START_IDX = 4      # without the app/cmd/len bytes, the data starts at byte
 
 def splitargs(cmdline):
     cmdline = cmdline.replace('\\\\"', '"').replace('\\"', '')
-    patt = re.compile('\".+?\"|\S+')
+    patt = re.compile(r'\".+?\"|\S+')
     for item in cmdline.split('\n'):
         return [s.strip('"') for s in patt.findall(item)]
 


### PR DESCRIPTION
XORWELL simply added an 'r' before strings used as regex pattern matching. There were only two such modifications.